### PR TITLE
Add the "-f" flag to rm so that it does not complain about missing files

### DIFF
--- a/text/Makefile
+++ b/text/Makefile
@@ -50,8 +50,8 @@ results:
 local_js: specs
 	@echo "Generate JS files and deploy them"
 	(cd results; make js_files json_files tidy)
-	-rm results/js/*_node.js
-	-rm results/js/*_node.js.gz
+	-rm -f results/js/*_node.js
+	-rm -f results/js/*_node.js.gz
 
 # This downloads already compiled JS and JSON files.  Use this if you
 # do not have the ability to compile JS files locally
@@ -156,7 +156,7 @@ help:
 
 distclean: clean
 	-rm -rf results tmp plots
-	$(foreach file, $(PDFs), $(shell rm "$(file)"))
+	$(foreach file, $(PDFs), $(shell rm -f "$(file)"))
 
 clean:
 	-rm -rf $(BUILDDIR)/*

--- a/text/source/_sphinxext/xogeny/templates/gen.makefile
+++ b/text/source/_sphinxext/xogeny/templates/gen.makefile
@@ -33,7 +33,7 @@ js/{{res}}.js.gz: js/{{res}}.js
 {% endfor %}
 
 tidy:
-	-rm *.o *.c *.h *.libs *.log *.makefile
+	-rm -f *.o *.c *.h *.libs *.log *.makefile
 	{% for res in results -%}
-	-rm {{res}}
+	-rm -f {{res}}
 	{% endfor %}


### PR DESCRIPTION
You might call it a pet peeve but I find it annoying seeing all the error messages about missing files when it doesn't really matter. In addition it makes it harder to detect real errors during compilation.
