### PR TITLE
Removes the indication that Resources is a Modelica Package

### DIFF
--- a/text/source/components/packages/package_def.rst
+++ b/text/source/components/packages/package_def.rst
@@ -232,7 +232,6 @@ discussed earlier, but with some resource files added::
         package.order          # Specifies an ordering for this	package
         datafile.mat           # Data specific to this package
       /Resources               # Resources are stored here by convention
-        package.mo             # Indicates Resources is a package
         logo.jpg               # An image file
 
 If we have a model that needs the data contained in


### PR DESCRIPTION
The point of the Resources directory is that one does
put any NON-Modelica material in here. So Resources should
most certainly not be marked as a Modelica package.
