### PR TITLE
Fixes #181 by making TODO list appear ONLY if condition is true

### DIFF
--- a/text/source/index.rst
+++ b/text/source/index.rst
@@ -48,14 +48,6 @@ Advanced Topics
 
    advanced
 
-TODO List
-=========
-
-.. toctree::
-   :maxdepth: 2
-
-   todo
-
 Indices and tables
 ==================
 
@@ -63,3 +55,12 @@ Indices and tables
 * :ref:`modindex`
 * :ref:`search`
 
+.. ifconfig:: todo_include_todos
+
+   TODO List
+   ---------
+
+   .. toctree::
+      :maxdepth: 2
+
+      todo


### PR DESCRIPTION
We can simply reuse the `todo_include_todos` condition.
However there is a little quirk to it when trying to hide
the TODO entry from the TOC. The conditional entry can only
be of lower level than the preceeding one. So that's why I
changed the level and put it under the "Indices and tables"
section.
