### PR TITLE
Correction: n times more than means actually (n+1) times

### DIFF
--- a/text/source/behavior/discrete/events.rst
+++ b/text/source/behavior/discrete/events.rst
@@ -151,7 +151,7 @@ Function                 Description
 ``Clock(i,r)``           A clock that fires every :math:`\frac{i}{r}` seconds where ``i`` and ``r`` are both of type ``Integer``
 ``Clock(dt)``            A clock that fires every :math:`dt` seconds where ``dt`` is a ``Real``
 ``subSample(u,s)``       A clock that samples ``s`` times slower than the clock used to sample ``u`` where ``s`` is an ``Integer``
-``superSample(u,s)``     A clock that samples ``s`` times faster than the clock used to sample ``u`` where ``s`` is an ``Integer``
+``superSample(u,s)``     A clock that samples ``s`` times as fast as the clock used to sample ``u`` where ``s`` is an ``Integer``
 ======================  ========================================================
 
 Note that the ``Clock`` constructor function is overloaded (*i.e.,*

--- a/text/source/behavior/discrete/measuring.rst
+++ b/text/source/behavior/discrete/measuring.rst
@@ -126,7 +126,7 @@ This technique for speed estimation can be represented in Modelica as:
 
 where ``tooth_angle`` represents :math:`\Delta\theta`.  Note how
 ``tooth_angle`` is not something the user needs to specify.  Instead,
-the user species the number of teeth using the ``teeth`` parameter.
+the user specifies the number of teeth using the ``teeth`` parameter.
 The ``tooth_angle`` parameter is then computed using the value of
 ``teeth`` (note that while we have hand coded the value of :math:`pi`
 here, we'll learn how to avoid this later in the book when we talk

--- a/text/source/behavior/discrete/sampling.rst
+++ b/text/source/behavior/discrete/sampling.rst
@@ -105,7 +105,7 @@ defined in terms of integer quantities which allow exact comparison.
 This means that when executing a simulation, we can know for certain
 that these two clocks will trigger simultaneously.
 
-If we wanted to create a clock that was exactly two times slower than
+If we wanted to create a clock that was exactly half as slow as  
 ``x``, we can use the ``subSample`` operator to accomplish this.  We
 see this in the definition of ``z``:
 
@@ -128,8 +128,8 @@ But by defining ``z`` using the ``subSample`` operator and defining it
 with respect to ``x`` we ensure that ``z`` is always triggering at
 half the frequency of ``x`` regardless of how ``x`` is defined.
 
-In a similar way, we can define another clock, ``w`` that triggers 3 times more
-frequently than ``x`` by using the ``superSample`` operator:
+In a similar way, we can define another clock, ``w`` that triggers 3 times as
+frequently as ``x`` by using the ``superSample`` operator:
 
 .. literalinclude:: /ModelicaByExample/DiscreteBehavior/SynchronousSystems/SamplingWithClocks.mo
    :language: modelica
@@ -142,7 +142,7 @@ Again, we could have defined ``w`` directly using ``sample`` with:
   w = sample(time, Clock(1,30));
 
 But by using ``superSample``, we can ensure that ``w`` is always
-sampling three times faster than ``x`` and six times faster than ``z``
+sampling three times as fast as ``x`` and six times as fast as ``z``
 (since ``z`` is also defined with respect to ``x``).
 
 The synchronous clock features in Modelica are relatively new.  As


### PR DESCRIPTION
If B is n times faster than A, then v_B = (n+1) v_A
 Therefore the correction in wording.