### PR TITLE
Variables of the state space output maybe be a state

### DIFF
--- a/text/source/behavior/arrays/state_space.rst
+++ b/text/source/behavior/arrays/state_space.rst
@@ -21,7 +21,7 @@ differential equations in the following form:
 
 In this form, :math:`x` represents the states in the system, :math:`u`
 represents any externally specified inputs to the system and :math:`y`
-represents the outputs of the system (*i.e.,* variables that are not
+represents the outputs of the system (*i.e.,* variables that may not be
 states, but can ultimately be computed from the values of the states
 and inputs).
 


### PR DESCRIPTION
A element in the output can also be a state variable. But the original
text states that y represents variable that are not states.