### PR TITLE
Change the fonts in plots to Droid Sans Fallback

### DIFF
--- a/text/source/_sphinxext/xogeny/plot_utils.py
+++ b/text/source/_sphinxext/xogeny/plot_utils.py
@@ -21,6 +21,8 @@ import os
 # for label in legend.get_lines():
 #     label.set_linewidth(1.5)  # the legend line width
 # plt.show()
+from matplotlib import rcParams
+rcParams['font.family'] = 'Droid Sans Fallback'
 
 def render_twoup_plot(name, spec1, spec2):
     pass


### PR DESCRIPTION
Change it so that non-western characters can be shown in the plot. 

It doesn't have to be Droid Sans, but I think everyone has that in Linux.