### PR TITLE
Typo?: and -> but not (maybe not is missing?)

### DIFF
--- a/text/source/behavior/functions/controller.rst
+++ b/text/source/behavior/functions/controller.rst
@@ -125,7 +125,7 @@ integration of the control strategy:
 In particular, note that ``computeHeat`` is invoked only within the
 ``when`` statement and not as part of a "continuous" equation.  As a
 result, we can be certain that ``computeHeat`` will only be invoked in
-response to an event and in evaluating candidate solutions for the
+response to an event but not in evaluating candidate solutions for the
 continuous variables.
 
 Results

--- a/text/source/behavior/functions/controller.rst
+++ b/text/source/behavior/functions/controller.rst
@@ -125,7 +125,7 @@ integration of the control strategy:
 In particular, note that ``computeHeat`` is invoked only within the
 ``when`` statement and not as part of a "continuous" equation.  As a
 result, we can be certain that ``computeHeat`` will only be invoked in
-response to an event but not in evaluating candidate solutions for the
+response to an event but not when evaluating candidate solutions for the
 continuous variables.
 
 Results


### PR DESCRIPTION
The C function with side-effect will only be invoked at the time event,
but not at evaluating the candidate solutions.