### PR TITLE
Hide version number in web page

### DIFF
--- a/text/source/_themes/xogeny-semantic/normal-page.html
+++ b/text/source/_themes/xogeny-semantic/normal-page.html
@@ -8,6 +8,8 @@
 
     <!-- Site Properities -->
     <meta name="generator" content="Sphinx 1.2" />
+    <meta name="description" content="Release {{ release }}" />
+
     {{ metatags() }}
 
     <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
@@ -37,9 +39,6 @@
 	  <img src="{{ pathto('_static/images/TitleHeading.png', 1) }}">
         </a>
 	<div class="ui divider"></div>
-	<p class="pull-right">
-	  <span class="pull-right">Release: {{ release }}</span>
-	</p>
 	<div class="ui breadcrumb">
 	  {%- for parent in parents %}
 	  <a class="section" href="{{ parent.link|e }}">{{ parent.title }}</a>


### PR DESCRIPTION
Moved version number of the book to meta data.
(Hidding them wouldn't be a option due to penalties by search engines.)

Put the data in meta="description".

Addressing issue #276