### PR TITLE
CircleCI: force updating docker image

### DIFF
--- a/docker/build_with_docker.sh
+++ b/docker/build_with_docker.sh
@@ -2,6 +2,8 @@
 image_name="xiedongping/book-mbe"
 echo $image_name
 
+sudo docker pull xiedongping/book-om
+sudo docker pull xiedongping/book-py
 sudo docker build --no-cache -t $image_name MBE
 sudo docker run -t -e "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
     -e "AWS_SECRET_KEY=$AWS_SECRET_KEY" \


### PR DESCRIPTION
Force updating the docker images from docker bay if upstream had
done so.

In newer version of docker we may use `docker build --pull`
instead.