### PR TITLE
Workaround to solve a problem in newer version of sphinx-intl

### DIFF
--- a/docker/PY/Dockerfile
+++ b/docker/PY/Dockerfile
@@ -39,3 +39,6 @@ RUN pip install --upgrade https://bitbucket.org/dietmarw/pygments-main/get/defau
 
 # Now install Git and grab the book
 RUN apt-get install -y git
+
+# Workaround: use an older version of sphinx-intl to workaround a bug in upstream
+RUN pip install --upgrade 'sphinx-intl==0.9.6'


### PR DESCRIPTION
The tags object in the conf.py cannot be found with newer versions
of the sphinx-intl, so the particular version is selected.