### PR TITLE
CircleCI: use old sphinx for internationalization

### DIFF
--- a/docker/PY/Dockerfile
+++ b/docker/PY/Dockerfile
@@ -42,3 +42,4 @@ RUN apt-get install -y git
 
 # Workaround: use an older version of sphinx-intl to workaround a bug in upstream
 RUN pip install --upgrade 'sphinx-intl==0.9.6'
+RUN pip install --upgrade 'sphinx==1.3'


### PR DESCRIPTION
There seem to be bug in the internationalization in the newer
verions of sphinx (see
https://github.com/django/djangoproject.com/issues/627).

So an old version is used here.