### PR TITLE
Fixes the mobi ebook generation again.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ dirhtml: deps
 json: deps
 	$(RUN) make json
 
-epub: deps
-	$(RUN) make epub
+ebooks: deps
+	$(RUN) make ebooks
 
 pdfs: deps
 	$(RUN) make pdf pdf-a4

--- a/text/Makefile
+++ b/text/Makefile
@@ -310,17 +310,18 @@ devhelp:
 	@echo "# devhelp"
 
 epub:
-	$(SPHINXBUILD) -b epub -t epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
-	-rm $(BUILDDIR)/epub/*.epub $(BUILDDIR)/epub/*.mobi
+	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
+	-rm $(BUILDDIR)/epub/*.epub
 	find $(BUILDDIR)/epub -name '*.xhtml' -exec ./inline-math.sh {} \;
 	(cd $(BUILDDIR)/epub; zip -r ModelicaByExample.epub .)
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
-mobi:   epub
-	(cd $(BUILDDIR)/epub; ebook-convert ModelicaByExample.epub ModelicaByExample.mobi)
+mobi:
+	$(SPHINXBUILD) -b epub -t mobi $(ALLSPHINXOPTS) $(BUILDDIR)/mobi
+	(cd $(BUILDDIR)/mobi; ebook-convert ModelicabyExample.epub ModelicaByExample.mobi)
 	@echo
-	@echo "Conversion to mobi finished. The mobi file is in $(BUILDDIR)/epub."
+	@echo "Build finished. The mobi file is in $(BUILDDIR)/mobi."
 
 ebooks: epub mobi
 

--- a/text/source/conf.py
+++ b/text/source/conf.py
@@ -31,12 +31,12 @@ extensions = ['sphinx.ext.doctest',
               'sphinx.ext.todo',
               'xogeny.sim',
               'matplotlib.sphinxext.plot_directive',
-              # 'sphinx.ext.pngmath',
-              'sphinx.ext.mathjax',
               'sphinx.ext.ifconfig']
 
-# As long as we are not generating with the epub tag it is save to use MathJax.
-# if 'epub' not in tags: extensions.append('sphinx.ext.mathjax')
+# As long as we are not generating with the mobi tag it is safe to us e MathJax.
+if 'mobi' not in tags: extensions.append('sphinx.ext.mathjax')
+# For mobi we need to use imgmath
+if 'mobi' in tags: extensions.append('sphinx.ext.imgmath')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Fixes the mobi generation

We actually have three versions now:
 1. epub with svg maths under epub/ModelicaByExample.epub
 2. epub with imgmaths under mobi/ModelicabyExample.epub (note the case)
 5. mobi with imgmaths under mobi/ModelicaByExample.mobi