### PR TITLE
Fixing all compilation warnings.

### DIFF
--- a/text/source/behavior/discrete/events.rst
+++ b/text/source/behavior/discrete/events.rst
@@ -181,7 +181,3 @@ synchronous clock features in Modelica are relatively new.  As such,
 they are not yet supported by all Modelica compilers.  To learn more
 about these synchronous features and their applications see
 [Elmqvist]_ and/or the Modelica Specification, version 3.3 or later.
-
-.. [Elmqvist] "Fundamentals of Synchronous Control in Modelica",
-	      Hilding Elmqvist, Martin Otter and Sven-Erik Mattsson
-	      http://www.ep.liu.se/ecp/076/001/ecp12076001.pdf

--- a/text/source/behavior/equations/first_order.rst
+++ b/text/source/behavior/equations/first_order.rst
@@ -10,8 +10,6 @@ Let us consider an extremely simple differential equation:
 Looking at this equation, we see there is only one variable,
 :math:`x`.  This equation can be represented in Modelica as follows:
 
-.. _ex_SimpleExample_FirstOrder:
-
 .. literalinclude:: /ModelicaByExample/BasicEquations/SimpleExample/FirstOrder.mo
    :language: modelica
    :lines: 2-
@@ -71,8 +69,6 @@ Now that we've solved this simple mathematical equation, let's turn
 our attention briefly to how we can make the model a bit more
 readable.  Consider the following model:
 
-.. _ex_SimpleExample_FirstOrderDocumented:
-
 .. literalinclude:: /ModelicaByExample/BasicEquations/SimpleExample/FirstOrderDocumented.mo
    :language: modelica
    :lines: 2-
@@ -120,8 +116,6 @@ the initial value of ``x`` in our model to be *2*, we could add an
 
 .. index:: initial equation
 
-.. _ex_SimpleExample_FirstOrderInitial:
-
 .. literalinclude:: /ModelicaByExample/BasicEquations/SimpleExample/FirstOrderInitial.mo
    :language: modelica
    :lines: 2-
@@ -166,8 +160,6 @@ this could be accomplished by specifying an initial condition of
 trivial to determine the initial state values that would satisfy such
 a requirement.  In those cases, it is possible to express the
 constraint that :math:`\dot{x}(0)=0` directly in Modelica as follows:
-
-.. _ex_SimpleExample_FirstOrderSteady:
 
 .. literalinclude:: /ModelicaByExample/BasicEquations/SimpleExample/FirstOrderSteady.mo
    :language: modelica

--- a/text/source/behavior/equations/population.rst
+++ b/text/source/behavior/equations/population.rst
@@ -235,7 +235,7 @@ initial population for both the predator and prey species, we might
 instead chose to initialize the system with some other equations that
 somehow capture the fact that the system is in equilibrium (you may
 remember this trick from the ``FirstOrderSteady`` model :ref:`discussed
-previously <ex_SimpleExample_FirstOrderSteady>`).  Fortunately,
+previously <first-order-init>`). Fortunately,
 Modelica's approach to initialization is rich enough to allow us to
 specify this (and many other) useful types of initial conditions.
 

--- a/text/source/components/architectures/sensor_comparison_ad.rst
+++ b/text/source/components/architectures/sensor_comparison_ad.rst
@@ -132,11 +132,11 @@ subsystems, we are also specifying the locations of the subsystems and
 the paths of the connections.  When rendered, our system architecture
 looks like this:
 
-.. image:: /ModelicaByExample/Architectures/SensorComparison/Examples/SystemArchitecture.*
-   :width: 100%
+.. figure:: /ModelicaByExample/Architectures/SensorComparison/Examples/SystemArchitecture.*
+   :width: 80%
    :align: center
    :alt: Top down architecture
-   :figclass: diagram
+   :figclass: align-center diagram
 
 Implementations
 ^^^^^^^^^^^^^^^

--- a/text/source/components/components/system_models.rst
+++ b/text/source/components/components/system_models.rst
@@ -189,7 +189,7 @@ chapter, *e.g.,*
 .. literalinclude:: /ModelicaByExample/Components/HeatTransfer/Examples/Cooling.mo
    :language: modelica
    :lines: 6-7
-   :emphasize-lines: 7
+   :emphasize-lines: 2
 
 The ``Placement`` annotation simply establishes a rectangular region
 in which to draw the icon associated with each component.  As with

--- a/text/source/components/subsystems/power_supply.rst
+++ b/text/source/components/subsystems/power_supply.rst
@@ -45,14 +45,14 @@ taking some collection of components and organizing them into a
 subsystem model.  Our system level circuit then becomes:
 
 .. image:: /ModelicaByExample/Subsystems/PowerSupply/Examples/SubsystemCircuit.*
-   :width: 100%
+   :width: 80%
    :align: center
    :alt: Hierarchical power supply model
 
 This model uses the ``BasicPowerSupply`` model whose diagram is shown here:
 
 .. image:: /ModelicaByExample/Subsystems/PowerSupply/Components/BasicPowerSupply.*
-   :width: 100%
+   :width: 80%
    :align: center
    :alt: Reusable power supply subsystem model
 
@@ -82,7 +82,7 @@ We can augment our system model to include an additional load (that
 comes online after some delay):
 
 .. image:: /ModelicaByExample/Subsystems/PowerSupply/Examples/AdditionalLoad.*
-   :width: 100%
+   :width: 80%
    :align: center
    :alt: Flat switching power supply model
 

--- a/text/source/conf.py
+++ b/text/source/conf.py
@@ -201,6 +201,9 @@ latex_elements = {
     pdfauthor = {Michael M. Tiller, Ph.D},
     pdfsubject = {Origin: http://book.xogeny.com},
     pdfkeywords = {Modelica, book, free-online}}''',
+
+# Figure placement within LaTeX paper
+    'figure_align': 'htb',
 }
 
 # If the tag 'a4' is given we switch to a4paper


### PR DESCRIPTION
Only ones left are:
```
/opt/MBE/ModelicaBook/text/source/advanced.rst: WARNING: document isn't included in any toctree
/opt/MBE/ModelicaBook/text/source/todo.rst: WARNING: document isn't included in any toctree
```
which can be ignored since they are not there by purpose.