### PR TITLE
Adds the "model" keyword for redeclaring a replaceable model

### DIFF
--- a/text/source/components/architectures/replaceable.rst
+++ b/text/source/components/architectures/replaceable.rst
@@ -374,7 +374,7 @@ If our ``Circuit`` is defined in this way, we can create the
 
     model SensitiveCircuit
       extends Circuit(
-        redeclare ResistorModel = SensitiveResistor(dRdT=0.1)
+        redeclare model ResistorModel = SensitiveResistor(dRdT=0.1)
       );
     end SensitiveCircuit;
 


### PR DESCRIPTION
I just read up on the replaceable/redeclare functionality of Modelica in the book and came across an error in the example code. I think when redeclaring a `replaceable model` the statement should start with `redeclare model` instead of just `redeclare` - at least this was the case for OpenModelica 1.12.0.