### PR TITLE
Plant Sensor line connects to wrong inertia body.

### DIFF
--- a/ModelicaByExample/Components/SpeedMeasurement/Examples/Plant.mo
+++ b/ModelicaByExample/Components/SpeedMeasurement/Examples/Plant.mo
@@ -3,10 +3,10 @@ model Plant "The basic plant model"
   extends ModelicaByExample.Components.Rotational.Examples.SMD;
   Components.IdealSensor idealSensor
     annotation (Placement(transformation(extent={{-10,-10},{10,10}},
-                          rotation=90, origin={-20,30})));
+                          rotation=90, origin={-20,50})));
 equation
   connect(idealSensor.flange, inertia1.flange_a) annotation (Line(
-      points={{-20,20},{-20,0},{-10,0}}, color={0,0,0},
+      points={{-20,40},{-90,40},{-90,0}}, color={0,0,0},
       smooth=Smooth.None));
   annotation(experiment(StopTime=10, Tolerance=1e-006));
 end Plant;


### PR DESCRIPTION
The model diagram view showed the sensor connected to inertia2.flange_a, however the text view declared the connection connected to inertia1.flange_a. The output was correct and matched the description in the training description, but the image sent me trying to figure out why the speed of inertia2 did not match the speed of the sensor. I have proposed a correction to the connection and moved the sensor up to separate the lines from the components.

Thanks for the training tool. It has been most informative. I am following the class on OpenModelica Connection Editor 1.19.2 (64-bit)