### PR TITLE
Fix a unit and update a term to be vectorized in ArrayEquations.HeatTransfer

### DIFF
--- a/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_ArrayComprehensions.mo
+++ b/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_ArrayComprehensions.mo
@@ -2,7 +2,7 @@ within ModelicaByExample.ArrayEquations.HeatTransfer;
 model Rod_ArrayComprehensions
   "Modeling heat conduction in a rod using array comprehensions"
   type Temperature=Real(unit="K", min=0);
-  type ConvectionCoefficient=Real(unit="W/K", min=0);
+  type ConvectionCoefficient=Real(unit="W/(m2.K)", min=0);
   type ConductionCoefficient=Real(unit="W.m-1.K-1", min=0);
   type Mass=Real(unit="kg", min=0);
   type SpecificHeat=Real(unit="J/(K.kg)", min=0);

--- a/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_ArrayComprehensionsOneEquation.mo
+++ b/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_ArrayComprehensionsOneEquation.mo
@@ -2,7 +2,7 @@ within ModelicaByExample.ArrayEquations.HeatTransfer;
 model Rod_ArrayComprehensionsOneEquation
   "Modeling heat conduction in a rod using single equation with array comprehensions"
   type Temperature=Real(unit="K", min=0);
-  type ConvectionCoefficient=Real(unit="W/K", min=0);
+  type ConvectionCoefficient=Real(unit="W/(m2.K)", min=0);
   type ConductionCoefficient=Real(unit="W.m-1.K-1", min=0);
   type Mass=Real(unit="kg", min=0);
   type SpecificHeat=Real(unit="J/(K.kg)", min=0);

--- a/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_ForLoop.mo
+++ b/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_ForLoop.mo
@@ -1,7 +1,7 @@
 within ModelicaByExample.ArrayEquations.HeatTransfer;
 model Rod_ForLoop "Modeling heat conduction in a rod using a for loop"
   type Temperature=Real(unit="K", min=0);
-  type ConvectionCoefficient=Real(unit="W/K", min=0);
+  type ConvectionCoefficient=Real(unit="W/(m2.K)", min=0);
   type ConductionCoefficient=Real(unit="W.m-1.K-1", min=0);
   type Mass=Real(unit="kg", min=0);
   type SpecificHeat=Real(unit="J/(K.kg)", min=0);

--- a/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_VectorNotation.mo
+++ b/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_VectorNotation.mo
@@ -2,7 +2,7 @@ within ModelicaByExample.ArrayEquations.HeatTransfer;
 model Rod_VectorNotation
   "Modeling heat conduction in a rod using vector notation"
   type Temperature=Real(unit="K", min=0);
-  type ConvectionCoefficient=Real(unit="W/K", min=0);
+  type ConvectionCoefficient=Real(unit="W/(m2.K)", min=0);
   type ConductionCoefficient=Real(unit="W.m-1.K-1", min=0);
   type Mass=Real(unit="kg", min=0);
   type SpecificHeat=Real(unit="J/(K.kg)", min=0);

--- a/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_VectorNotationNoSubscripts.mo
+++ b/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_VectorNotationNoSubscripts.mo
@@ -2,7 +2,7 @@ within ModelicaByExample.ArrayEquations.HeatTransfer;
 model Rod_VectorNotationNoSubscripts
   "Modeling heat conduction in a rod using vector notation"
   type Temperature=Real(unit="K", min=0);
-  type ConvectionCoefficient=Real(unit="W/K", min=0);
+  type ConvectionCoefficient=Real(unit="W/(m2.K)", min=0);
   type ConductionCoefficient=Real(unit="W.m-1.K-1", min=0);
   type Mass=Real(unit="kg", min=0);
   type SpecificHeat=Real(unit="J/(K.kg)", min=0);


### PR DESCRIPTION
Fixes two bugs in the `HeatTransfer` examples in ch. 3.

### Wrong unit for `ConvectionCoefficient` 

Fixes #454

### Missing vectorization

The first term of the derivative that [uses vector notation](https://github.com/mtiller/ModelicaBook/blob/b07a59eb08814a1be48ddf30e70a36cef4ee6835/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_VectorNotation.mo#L34C35-L34C44) has two problems:
1. it refers to the variable `i`, which is never declared in this example
2. it results in a scalar rather than a vector

The solution presented in this PR is straightforward: Replace
```modelica
 -h*A_s*(T[i]-Tamb)
```
with
```modelica
-h*A_s*(T[2:n-1]-fill(Tamb, n-2))
```
