### PR TITLE
fix: correct interior-node convection term in Rod_VectorNotation (MIC-66)

### DIFF
--- a/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_VectorNotation.mo
+++ b/ModelicaByExample/ArrayEquations/HeatTransfer/Rod_VectorNotation.mo
@@ -31,6 +31,6 @@ initial equation
   T = linspace(200,300,n);
 equation
   rho*V*C*der(T[1]) = -h*A_s*(T[1]-Tamb)-k*A_c*(T[1]-T[2])/(L/n);
-  rho*V*C*der(T[2:n-1]) = -h*A_s*(T[i]-Tamb)-k*A_c*(T[2:n-1]-T[1:n-2])/(L/n)-k*A_c*(T[2:n-1]-T[3:n])/(L/n);
+  rho*V*C*der(T[2:n-1]) = -h*A_s*(T[2:n-1].-Tamb)-k*A_c*(T[2:n-1]-T[1:n-2])/(L/n)-k*A_c*(T[2:n-1]-T[3:n])/(L/n);
   rho*V*C*der(T[end]) = -h*A_s*(T[end]-Tamb)-k*A_c*(T[end]-T[end-1])/(L/n);
 end Rod_VectorNotation;


### PR DESCRIPTION
Fixes **MIC-66**.

The middle vectorized energy-balance equation in `Rod_VectorNotation.mo` had two problems:
1. It referenced an undefined scalar `T[i]` — should be the interior slice `T[2:n-1]`.
2. `(T[2:n-1] - Tamb)` subtracts a scalar from a vector, which strict Modelica / OMC 1.24 does not broadcast with `-`. Uses the element-wise operator `(T[2:n-1] .- Tamb)`.

**Verified** with OpenModelica 1.24.0 / MSL 3.2.3: passes `checkModel` **and** simulates successfully (DASSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)