### PR TITLE
fix: restore protected population in RegionalPopulation (MIC-67)

### DIFF
--- a/ModelicaByExample/Components/LotkaVolterra/Components/RegionalPopulation.mo
+++ b/ModelicaByExample/Components/LotkaVolterra/Components/RegionalPopulation.mo
@@ -12,7 +12,7 @@ model RegionalPopulation "Population of animals in a specific region"
   Interfaces.Species species
     annotation (Placement(transformation(extent={{-10,90},{10,110}}),
         iconTransformation(extent={{-10,90},{10,110}})));
-public
+protected
   Real population(start=10) = species.population "Population in this region";
 initial equation
   if init==InitializationOptions.FixedPopulation then


### PR DESCRIPTION
Fixes **MIC-67**.

Commit `00e04171` (Feb 2025) flipped `population` from `protected` to `public` just to get it compiling, with a note that the cause was unclear. 

Under OpenModelica 1.24.0 / MSL 3.2.3 the `protected` binding checks cleanly — I isolated the pattern (a protected variable bound to a connector's potential variable) and confirmed `protected` vs `public` makes no difference on current OMC. The 2025 error was version-specific. This reverts to `protected`, restoring the original pedagogy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)