### PR TITLE
feat: add model regression check tool (MIC-71)

### DIFF
--- a/tools/check-models/README.md
+++ b/tools/check-models/README.md
@@ -1,0 +1,49 @@
+# Model regression check
+
+A guard that every class in the `ModelicaByExample` library still passes
+`checkModel` under a modern OpenModelica. It exists so that future OpenModelica
+or Modelica Standard Library upgrades can't silently break book examples.
+
+## Usage
+
+```sh
+tools/check-models/run.sh
+```
+
+It runs `omc` in Docker (Docker Desktop or colima), installs the target MSL into
+a host cache on first run, checks every class, and prints a verdict:
+
+```
+Checked 518 classes: 516 passed, 2 failed (2 known, 0 unexpected).
+
+OK — no regressions.
+```
+
+Exit status is `0` when the only failures are ones listed in
+`known_failures.txt`, and `1` when something new breaks (a regression) — so it
+can gate CI.
+
+## Configuration (environment variables)
+
+| Variable      | Default                                          | Purpose                          |
+|---------------|--------------------------------------------------|----------------------------------|
+| `OMC_IMAGE`   | `openmodelica/openmodelica:v1.24.0-minimal`      | Docker image providing `omc`     |
+| `MSL_VERSION` | `3.2.3`                                           | Modelica Standard Library to load |
+| `OMC_LIBS`    | `~/.cache/mbe-omc-libs`                           | Host cache for the installed MSL |
+
+To test the book against a newer compiler, bump `OMC_IMAGE` (and, if the book
+migrates, `MSL_VERSION`) and re-run.
+
+## Known failures
+
+`known_failures.txt` lists classes that are expected to fail, each with the
+reason and the tracking issue. The runner tolerates these and reports any that
+start passing again (so the list can be pruned). Update it deliberately — adding
+a class here silences it.
+
+## Files
+
+- `run.sh` — the runner (host: docker + python3).
+- `check_all.mos.in` — OMC script template; `@MSL_VERSION@` is substituted in.
+- `parse.py` — turns the raw sweep output into a pass/fail verdict.
+- `known_failures.txt` — the allowlist of expected failures.

--- a/tools/check-models/check_all.mos.in
+++ b/tools/check-models/check_all.mos.in
@@ -1,0 +1,16 @@
+// check_all.mos.in — template; the runner substitutes @MSL_VERSION@.
+//
+// Loads the target Modelica Standard Library and the ModelicaByExample
+// package, then runs checkModel on every class (recursively) and prints a
+// machine-parseable record of the result for each one. parse.py turns this
+// into a pass/fail verdict against known_failures.txt.
+loadModel(Modelica, {"@MSL_VERSION@"}); getErrorString();
+loadFile("/work/ModelicaByExample/package.mo"); getErrorString();
+
+names := getClassNames(ModelicaByExample, recursive=true, qualified=true);
+for name in names loop
+  print("@@@MODEL " + typeNameString(name) + "\n");
+  print(checkModel(name));
+  print("\n@@@ERR " + getErrorString() + "\n");
+end for;
+print("@@@DONE\n");

--- a/tools/check-models/known_failures.txt
+++ b/tools/check-models/known_failures.txt
@@ -1,0 +1,18 @@
+# Classes in ModelicaByExample that are known to fail `checkModel` under the
+# modern OpenModelica baseline, with the reason. The regression runner treats
+# these as expected: it fails ONLY on a class that breaks but is not listed
+# here (a genuine regression). If a listed class starts passing again, the
+# runner reports it so the entry can be removed.
+#
+# One fully-qualified class name per line; `#` starts a comment.
+
+# MIC-68 — "Attempt to implement on-off control": references `setpoint`, which
+# is not in scope. May be an intentionally-flawed illustrative example (it
+# carries a red "?" in its diagram). Pending author decision.
+ModelicaByExample.Architectures.ThermalControl.Implementations.ConventionalOnOffControl
+
+# MIC-69 — OMC new-frontend internal error (NFScalarize "could not expand
+# C*x + D*u") on this PARTIAL model with unbound dimension parameters. Its
+# concrete extender (StateSpace.Examples.LotkaVolterra) checks fine, so no
+# built example is affected. Upstream OMC bug; see MIC-83.
+ModelicaByExample.ArrayEquations.StateSpace.ABCD

--- a/tools/check-models/parse.py
+++ b/tools/check-models/parse.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Parse the output of check_all.mos and verdict it against known_failures.txt.
+
+Reads the raw OMC sweep output on stdin (or a file argument), splits it into
+per-class blocks, and classifies each class as pass/fail. A class fails if its
+checkModel result does not say "completed successfully" or if its error string
+contains an "Error:" line.
+
+Exit status:
+  0  no unexpected failures (clean, or only known failures)
+  1  at least one unexpected failure (a regression)
+"""
+import re
+import sys
+
+KNOWN_PATH = __file__.rsplit("/", 1)[0] + "/known_failures.txt"
+
+
+def load_known(path):
+    known = set()
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.split("#", 1)[0].strip()
+                if line:
+                    known.add(line)
+    except FileNotFoundError:
+        pass
+    return known
+
+
+def parse(text):
+    blocks = text.split("@@@MODEL ")[1:]
+    results = {}  # name -> (ok, [error lines])
+    for b in blocks:
+        name = b.split("\n", 1)[0].strip()
+        ok = "completed successfully" in b
+        errs = [e.strip() for e in re.findall(r"Error:.*", b)]
+        results[name] = (ok and not errs, errs)
+    return results
+
+
+def main():
+    text = open(sys.argv[1], encoding="utf-8", errors="replace").read() \
+        if len(sys.argv) > 1 else sys.stdin.read()
+    known = load_known(KNOWN_PATH)
+    results = parse(text)
+
+    total = len(results)
+    failures = {n: errs for n, (ok, errs) in results.items() if not ok}
+    unexpected = {n: e for n, e in failures.items() if n not in known}
+    expected = {n: e for n, e in failures.items() if n in known}
+    fixed = sorted(known - set(failures))
+
+    print(f"Checked {total} classes: "
+          f"{total - len(failures)} passed, {len(failures)} failed "
+          f"({len(expected)} known, {len(unexpected)} unexpected).")
+
+    if fixed:
+        print("\nKnown failures that now PASS "
+              "(remove from known_failures.txt):")
+        for n in fixed:
+            print(f"  + {n}")
+
+    if unexpected:
+        print("\nUNEXPECTED failures (regressions):")
+        for n in sorted(unexpected):
+            print(f"  - {n}")
+            for e in dict.fromkeys(unexpected[n]):  # de-dup, keep order
+                print(f"      {e[:200]}")
+        return 1
+
+    print("\nOK — no regressions.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check-models/run.sh
+++ b/tools/check-models/run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Regression check for the ModelicaByExample library.
+#
+# Runs `checkModel` on every class in the library under a modern OpenModelica
+# (in Docker) and fails if any class breaks that is not already listed in
+# known_failures.txt. Intended for local use and for CI (see Phase 2 / MIC-75).
+#
+# Configurable via environment variables:
+#   OMC_IMAGE    Docker image providing omc   (default: openmodelica/openmodelica:v1.24.0-minimal)
+#   MSL_VERSION  Modelica Standard Library     (default: 3.2.3)
+#   OMC_LIBS     Host dir caching installed MSL (default: ~/.cache/mbe-omc-libs)
+#
+# Requires: docker (e.g. Docker Desktop or colima) and python3 on the host.
+set -euo pipefail
+
+OMC_IMAGE="${OMC_IMAGE:-openmodelica/openmodelica:v1.24.0-minimal}"
+MSL_VERSION="${MSL_VERSION:-3.2.3}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+LIBS="${OMC_LIBS:-$HOME/.cache/mbe-omc-libs}"
+# Keep the work dir under $HOME so it is shared into the Docker VM. colima only
+# mounts the home directory by default, so a /tmp or /var/folders mktemp dir
+# would show up empty inside the container.
+CACHE_BASE="${XDG_CACHE_HOME:-$HOME/.cache}"
+mkdir -p "$CACHE_BASE" "$LIBS"
+WORK="$(mktemp -d "$CACHE_BASE/mbe-check.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# 1. Install the target MSL into the (persistent) cache if it isn't there yet.
+if ! ls -d "$LIBS"/Modelica\ * >/dev/null 2>&1; then
+  echo "Installing Modelica $MSL_VERSION into $LIBS ..."
+  printf 'installPackage(Modelica, "%s", exactMatch=false); getErrorString();\n' \
+    "$MSL_VERSION" > "$WORK/install.mos"
+  docker run --rm \
+    -v "$LIBS":/root/.openmodelica/libraries \
+    -v "$WORK":/mos \
+    "$OMC_IMAGE" omc /mos/install.mos
+fi
+
+# 2. Render the check script from its template and run the sweep.
+sed "s/@MSL_VERSION@/$MSL_VERSION/g" "$HERE/check_all.mos.in" > "$WORK/check_all.mos"
+echo "Checking all models with $OMC_IMAGE (MSL $MSL_VERSION) ..."
+docker run --rm \
+  -v "$REPO":/work \
+  -v "$LIBS":/root/.openmodelica/libraries \
+  -v "$WORK":/mos \
+  "$OMC_IMAGE" omc /mos/check_all.mos > "$WORK/sweep.out" 2>&1
+
+# 3. Verdict the sweep against the known-failures allowlist.
+python3 "$HERE/parse.py" "$WORK/sweep.out"


### PR DESCRIPTION
Fixes **MIC-71**.

Adds `tools/check-models/` — a repeatable guard that every class in `ModelicaByExample` still passes `checkModel` under a modern OpenModelica:

- `run.sh` — runs the sweep in Docker, verdicts against the allowlist, exits non-zero on *new* failures. Configurable via `OMC_IMAGE` / `MSL_VERSION` / `OMC_LIBS`.
- `check_all.mos.in` — OMC script template (enumerate all classes, checkModel each).
- `parse.py` — pass/fail verdict; also reports known failures that have started passing.
- `known_failures.txt` — allowlist (currently ConventionalOnOffControl/MIC-68 and ABCD/MIC-69, with reasons).
- `README.md` — usage + config.

**Validated** cold and warm: `Checked 518 classes: 516 passed, 2 failed (2 known, 0 unexpected). OK — no regressions. (exit 0)`. Ready to wire into CI under MIC-75. Host deps: docker + python3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)