### PR TITLE
ci: bump deprecated @v3 GitHub Actions to @v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,30 +13,30 @@ jobs:
       - name: Mark checkout directory as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Restore DVC Cache
         id: dvc-cache-restore
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         with:
           path: .dvc/cache
           key: dvc-cache-key
       - name: Make PDFs
         run: make env pdfs
       - name: Upload Executables
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: exes.tar.gz
           path: text/results/exes.tar.gz
       - name: Generate JSON
         run: make env json
       - name: Archive Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: text/build
       - name: Save DVC Cache
         id: dvc-cache-save
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: .dvc/cache
           key: dvc-cache-key
@@ -49,18 +49,18 @@ jobs:
       - name: Mark checkout directory as safe
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Download Build Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: text/build
       - name: Publish Web Site
         run: make site
       - name: Archive Site
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: korean-site
           path: nextgen/dist
@@ -81,11 +81,11 @@ jobs:
           NETLIFY_SITE_ID: op://Automation/w75bbkgjyx35y3uryrfhfisz7e/username
           NETLIFY_AUTH_TOKEN: op://Automation/w75bbkgjyx35y3uryrfhfisz7e/password
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Download Korean Site
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: korean-site
           path: nextgen/dist


### PR DESCRIPTION
## Why

The `build` workflow has been failing in ~5s on every push to `master`. GitHub now hard-fails any workflow referencing the deprecated v3 artifact actions:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`.

It dies during *Prepare all required actions*, before any real build step runs — so nothing has reached Netlify since the deprecation took effect.

## What

Bumps all `@v3` action references in `.github/workflows/build.yaml` to `@v4`:

| Action | Count |
|---|---|
| `actions/checkout` | 3 |
| `actions/cache/restore` | 1 |
| `actions/cache/save` | 1 |
| `actions/upload-artifact` | 3 |
| `actions/download-artifact` | 2 |

## Compat note

`upload-artifact@v4` makes artifact names immutable within a single run (you can't upload twice with the same name). This workflow uploads `exes.tar.gz`, `build-artifacts`, and `korean-site` exactly once each, so it's safe.

## Out of scope

The `generate_site` job still runs in `image: node:14`, which is EOL. That's tracked separately (MIC-95) so we don't conflate two independent risk profiles in one PR — bumping Node against this 2019-era `book-nextgen` stack could break the build in non-obvious ways and shouldn't ride on the urgent CI unblock.

Fixes MIC-94.