### PR TITLE
ci: restore DVC incremental builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: .dvc/cache
-          key: dvc-cache-key
+          key: dvc-cache-${{ hashFiles('.github/workflows/build.yaml', 'text/dvc.lock', 'text/dvc.yaml', 'text/specs.py', 'ModelicaByExample/**/*.mo') }}
+          restore-keys: |
+            dvc-cache-
       - name: Make PDFs
         run: make env pdfs
       - name: Upload Executables
@@ -36,10 +38,11 @@ jobs:
           path: text/build
       - name: Save DVC Cache
         id: dvc-cache-save
+        if: always() && steps.dvc-cache-restore.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           path: .dvc/cache
-          key: dvc-cache-key
+          key: ${{ steps.dvc-cache-restore.outputs.cache-primary-key }}
   generate_site:
     runs-on: ubuntu-latest
     needs: generate_results

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ all: specs results json ebooks pdfs
 env:
 	dvc cache dir .dvc/cache
 	-mkdir .dvc/cache
-	rm -f text/dvc.lock
 	uname -m > text/build-arch
 	-rm -rf "$(HOME)/.openmodelica/libraries/ModelicaByExample 0.6.0" 
 	mkdir -p $(HOME)/.openmodelica/libraries


### PR DESCRIPTION
## Problem

`generate_results` rebuilds every Modelica model from scratch on every push (~14 min), even when no model has changed. The fine-grained DVC pipeline in `text/dvc.yaml` is *designed* for incremental builds — each model is its own stage with explicit `deps` and `outs` — but two bugs in the wrapper around it defeat the mechanism.

### Bug 1: `Makefile`'s `env` target deletes the lockfile every run
```makefile
env:
    dvc cache dir .dvc/cache
    -mkdir .dvc/cache
    rm -f text/dvc.lock          # ← detonates incremental builds
```
Without `text/dvc.lock`, DVC has no record of what was previously built, so it re-runs every `build-case-*` stage from scratch.

### Bug 2: `actions/cache` key is static
```yaml
key: dvc-cache-key
```
`actions/cache@v4` is immutable-on-write: once a key exists, `save` is a no-op. So `.dvc/cache` was persisted *once* (whenever the workflow first succeeded after this was added) and has never been updated since.

## Changes

1. **`Makefile`:** stop deleting `text/dvc.lock` in the `env` target. Trust the committed lockfile.

2. **`.github/workflows/build.yaml`:** make the cache key content-aware.
   ```yaml
   key: dvc-cache-${{ hashFiles('.github/workflows/build.yaml',
                                'text/dvc.lock',
                                'text/dvc.yaml',
                                'text/specs.py',
                                'ModelicaByExample/**/*.mo') }}
   restore-keys: |
     dvc-cache-
   ```
   Including the workflow file in the hash captures the pinned `book-builder-image` tag — so bumping the builder image automatically busts the cache. That handles the toolchain-drift concern that originally justified `rm dvc.lock`.

3. **Save step:** skip when there was an exact-key cache hit (would be a no-op anyway), and reuse `cache-primary-key` from restore to avoid any drift between the two steps.

## Expected payoff

| Change type | Before | After (expected) |
|---|---|---|
| Code-only PR (no `.mo` / `dvc.lock` change) | ~14 min | ~1–2 min |
| One model changed | ~14 min | ~1–2 min + that stage |
| Builder image bumped | ~14 min | ~14 min (correct — cache busts) |

## Risk

The **first** post-merge run will only get a `restore-keys` partial hit — the existing `dvc-cache-key` cache content was written without `dvc.lock` awareness, so DVC may decide a chunk of stages need rebuilding. From the second run onward, code-only changes should converge to the fast path.

## Sequencing

This goes in before MIC-95 (Node bumps). Once green, MIC-95 will rebase onto this so each Node-bump CI cycle is ~3 min instead of ~17 min — makes iterating one major Node release at a time actually pleasant.

Fixes MIC-99.