### PR TITLE
ci(MIC-100): cache text/build to skip unchanged Sphinx pages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,18 @@ jobs:
           key: sphinx-build-${{ hashFiles('.github/workflows/build.yaml', 'text/source/**', 'text/locale/kr/**', 'text/Makefile') }}
           restore-keys: |
             sphinx-build-
+      - name: Restore CI Deps Cache (DVC outputs + plots)
+        id: cideps-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            text/results
+            text/plots
+            text/docs-dir
+          key: ci-deps-${{ hashFiles('.github/workflows/build.yaml', 'text/dvc.lock', 'text/dvc.yaml', 'text/specs.py', 'ModelicaByExample/**/*.mo') }}
       - name: Make PDFs
+        env:
+          CI_BUILD: ${{ steps.cideps-cache-restore.outputs.cache-hit == 'true' && '1' || '0' }}
         run: make env pdfs
       - name: Upload Executables
         uses: actions/upload-artifact@v4
@@ -41,6 +52,8 @@ jobs:
           name: exes.tar.gz
           path: text/results/exes.tar.gz
       - name: Generate JSON
+        env:
+          CI_BUILD: ${{ steps.cideps-cache-restore.outputs.cache-hit == 'true' && '1' || '0' }}
         run: make env json
       - name: Archive Build Artifacts
         uses: actions/upload-artifact@v4
@@ -61,6 +74,16 @@ jobs:
         with:
           path: text/build
           key: ${{ steps.sphinx-cache-restore.outputs.cache-primary-key }}
+      - name: Save CI Deps Cache
+        id: cideps-cache-save
+        if: always() && steps.cideps-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            text/results
+            text/plots
+            text/docs-dir
+          key: ${{ steps.cideps-cache-restore.outputs.cache-primary-key }}
   generate_site:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Full Build')
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,14 @@ jobs:
           key: dvc-cache-${{ hashFiles('.github/workflows/build.yaml', 'text/dvc.lock', 'text/dvc.yaml', 'text/specs.py', 'ModelicaByExample/**/*.mo') }}
           restore-keys: |
             dvc-cache-
+      - name: Restore Sphinx Build Cache
+        id: sphinx-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: text/build
+          key: sphinx-build-${{ hashFiles('.github/workflows/build.yaml', 'text/source/**', 'text/locale/kr/**', 'text/Makefile') }}
+          restore-keys: |
+            sphinx-build-
       - name: Make PDFs
         run: make env pdfs
       - name: Upload Executables
@@ -46,6 +54,13 @@ jobs:
         with:
           path: .dvc/cache
           key: ${{ steps.dvc-cache-restore.outputs.cache-primary-key }}
+      - name: Save Sphinx Build Cache
+        id: sphinx-cache-save
+        if: always() && steps.sphinx-cache-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: text/build
+          key: ${{ steps.sphinx-cache-restore.outputs.cache-primary-key }}
   generate_site:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Full Build')
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,28 @@
 
 .PHONY: specs results dirhtml ebooks api publish_server publish_web serve
 
+# When CI_BUILD=1, the json/dirhtml/pdfs targets skip the specs+results
+# (DVC repro) dependency chain and assume text/results, text/plots, and
+# text/docs-dir are already populated (e.g. restored from cache in CI).
+# text/Makefile already has matching CI_BUILD support that drops the same
+# deps from its sphinx targets. Default (CI_BUILD=0) preserves the old
+# behavior so local builds work unchanged.
+CI_BUILD ?= 0
+ifeq ($(CI_BUILD),1)
+SPHINX_DEPS =
+else
+SPHINX_DEPS = results
+endif
+
 all: specs results json ebooks pdfs
 
 env:
 	dvc cache dir .dvc/cache
 	-mkdir .dvc/cache
 	uname -m > text/build-arch
-	-rm -rf "$(HOME)/.openmodelica/libraries/ModelicaByExample 0.6.0" 
+	-rm -rf "$(HOME)/.openmodelica/libraries/ModelicaByExample 0.6.0"
 	mkdir -p $(HOME)/.openmodelica/libraries
-	ln -s $(PWD)/ModelicaByExample "$(HOME)/.openmodelica/libraries/ModelicaByExample 0.6.0" 
+	ln -s $(PWD)/ModelicaByExample "$(HOME)/.openmodelica/libraries/ModelicaByExample 0.6.0"
 
 specs:
 	(cd text; make specs)
@@ -25,10 +38,10 @@ specs:
 results: env specs
 	(cd text; make results)
 
-dirhtml:
+dirhtml: $(SPHINX_DEPS)
 	(cd text; make dirhtml)
 
-json: results
+json: $(SPHINX_DEPS)
 	(cd text; make json json_kr)
 
 ebooks:

--- a/text/Makefile
+++ b/text/Makefile
@@ -47,7 +47,7 @@ SET_BOOK_LANG_KR = BOOK_LANG=kr
 
 # For CI we don't want to rebuild the whole dependencies each time.
 # To enable the CI build do, e.g., `make CI_BUILD=1 pdf`
-CI_BUILD=0
+CI_BUILD ?= 0
 ifeq ($(CI_BUILD),1)
 SPHINXDEPS =
 else

--- a/text/Makefile
+++ b/text/Makefile
@@ -48,8 +48,11 @@ SET_BOOK_LANG_KR = BOOK_LANG=kr
 # For CI we don't want to rebuild the whole dependencies each time.
 # To enable the CI build do, e.g., `make CI_BUILD=1 pdf`
 CI_BUILD ?= 0
+# CI_BUILD=1 skips the expensive simulation (specs+results=dvc repro) but
+# still runs 'images' because svg->pdf conversion is fast and the converted
+# PDFs aren't checked in (the latex builder needs them).
 ifeq ($(CI_BUILD),1)
-SPHINXDEPS =
+SPHINXDEPS = images
 else
 SPHINXDEPS = specs results images
 endif


### PR DESCRIPTION
## Result

`generate_results` drops from **~12m to ~3m 28s** on a no-source-change rerun (most of the remaining time is GitHub-runner container init, not work).

| Step | Before | After |
|---|---|---|
| Make PDFs | 3m 33s | **41s** |
| Generate JSON | 7m 34s | **14s** |
| Total | ~12m | **~3m 28s** |

Verified on commit `16453b57` (run [28406940388](https://github.com/mtiller/ModelicaBook/actions/runs/28406940388)).

## What was actually wrong

The first cache I tried (Sphinx `text/build`) saved <30s because the real bottleneck wasn't Sphinx. Drilling into the logs showed `dvc repro dvc.yaml` was eating 2m 43s in *Make PDFs* and ~6m in *Generate JSON*, just walking 30+ already-cached stages to confirm they're up to date.

Then it turned out `CI_BUILD=1` (which exists in `text/Makefile` precisely to skip this) didn't work for two reasons:

1. **`text/Makefile` had `CI_BUILD=0` instead of `CI_BUILD ?= 0`** — clobbering any env-var override. The comment promised \"to enable the CI build do `make CI_BUILD=1 pdf`\", but the line below unconditionally reset it.
2. **The root `Makefile`'s `json:` target depended on `results:`** unconditionally, so even when `text/Makefile` honored `CI_BUILD`, the root invocation forced a full DVC run.

Fixing both, then keeping `images` (svg→pdf) in the build chain (the latex builder needs the converted PDFs, which aren't checked in), gives the speedup.

## Changes

1. **`text/Makefile`**: `CI_BUILD=0` → `CI_BUILD ?= 0`; keep `images` in `SPHINXDEPS` even under CI_BUILD=1.
2. **`Makefile` (root)**: mirror the `CI_BUILD` switch on the `json:` and `dirhtml:` targets so they drop the `results` dep when set.
3. **`.github/workflows/build.yaml`**:
   - Cache `text/results`, `text/plots`, `text/docs-dir` keyed on `dvc.lock` + `.mo` files + `specs.py` + workflow.
   - Set `CI_BUILD: 1` env on Make PDFs / Generate JSON when that cache hits; `CI_BUILD: 0` when it misses (preserves correctness for source changes).
   - Also kept a smaller Sphinx `text/build` cache; modest extra win on xelatex.

## Behavior matrix

| Change kind | ci-deps cache | CI_BUILD | What runs |
|---|---|---|---|
| Code/CI tweak (no source change) | hit | 1 | Sphinx + xelatex only (~3m total) |
| Single `.mo` edit | miss | 0 | full DVC repro (only the affected stage recomputes thanks to DVC); cache then re-saves |
| `specs.py` / `dvc.lock` change | miss | 0 | same as above |
| Builder-image bump in workflow | miss | 0 | full rebuild (correct) |

## Risks

- The ci-deps cache assumes `text/results` + `text/plots` + `text/docs-dir` are the complete set of `dvc repro` outputs Sphinx consumes. If a future Sphinx extension reaches into another DVC-produced location, it'll silently get a stale file. Mitigation is the hash-key invalidation on `dvc.lock`.
- Cache size measured at ~35MB for Sphinx + a few hundred MB for ci-deps (DVC outputs). Within the 10GB GHA quota.

Closes MIC-100.